### PR TITLE
add deps to get image running again, note head is broken

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,8 +29,8 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`xemu_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/xemu-project/xemu/releases/latest" | jq -r '. | .tag_name')
-          echo "Type is \`github_stable\`" >> $GITHUB_STEP_SUMMARY
+          EXT_RELEASE=$(echo v0.8.133)
+          echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^xemu_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Github organizational variable \`SKIP_EXTERNAL_TRIGGER\` matches current external release; skipping trigger." >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN \
     | awk -F '(": "|")' '/browser.*x86_64.AppImage/ && !/.*dbg.*/ {print $3}') && \
   curl -o \
     /tmp/xemu.app -L \
-    "${DOWNLOAD_URL}" && \
+    "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-0.8.133-x86_64.AppImage" && \
   cd /tmp && \
   chmod +x xemu.app && \
   ./xemu.app --appimage-extract && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=xemu
+ENV TITLE=xemu \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \
@@ -21,6 +22,7 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libgtk-3-common \
+    libpipewire-0.3 \
     libusb-1.0-0 && \
   DOWNLOAD_URL=$(curl -sX GET "https://api.github.com/repos/xemu-project/xemu/releases/latest" \
     | awk -F '(": "|")' '/browser.*x86_64.AppImage/ && !/.*dbg.*/ {print $3}') && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,7 +10,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=xemu
+ENV TITLE=xemu \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -27,7 +27,7 @@ RUN \
     | awk -F '(": "|")' '/browser.*aarch64.AppImage/ && !/.*dbg.*/ {print $3}') && \
   curl -o \
     /tmp/xemu.app -L \
-    "${DOWNLOAD_URL}" && \
+    "https://github.com/xemu-project/xemu/releases/download/v0.8.133/xemu-0.8.133-aarch64.AppImage" && \
   cd /tmp && \
   chmod +x xemu.app && \
   ./xemu.app --appimage-extract && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,23 +145,16 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a stable github release use the latest endpoint from github to determine the ext tag
-    stage("Set ENV github_stable"){
-     steps{
-       script{
-         env.EXT_RELEASE = sh(
-           script: '''curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
-           returnStdout: true).trim()
-       }
-     }
-    }
-    // If this is a stable or devel github release generate the link for the build message
-    stage("Set ENV github_link"){
-     steps{
-       script{
-         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
-       }
-     }
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
+      steps{
+        script{
+          env.EXT_RELEASE = sh(
+            script: ''' echo v0.8.133 ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
+        }
+      }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -1030,7 +1023,7 @@ pipeline {
                   "type": "commit",\
                   "tagger": {"name": "LinuxServer-CI","email": "ci@linuxserver.io","date": "'${GITHUB_DATE}'"}}'
               echo "Pushing New release for Tag"
-              curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. |.body' > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               jq -n \
                 --arg tag_name "$META_TAG" \
                 --arg target_commitish "master" \

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **20.12.25:** - Add libpipewire dep for appimage, head is broken use tag v0.8.133-ls57.
+* **20.12.25:** - Add libpipewire dep for appimage, pin to v0.8.133.
 * **20.12.25:** - Add libusb dep for appimage.
 * **20.12.25:** - Add Wayland init logic.
 * **07.07.25:** - Install GTK libs for file chooser.

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.12.25:** - Add libpipewire dep for appimage, head is broken use tag v0.8.133-ls57.
 * **20.12.25:** - Add libusb dep for appimage.
 * **20.12.25:** - Add Wayland init logic.
 * **07.07.25:** - Install GTK libs for file chooser.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-xemu
-external_type: github_stable
+external_type: na
+custom_version_command: "echo v0.8.133"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,7 +107,7 @@ init_diagram: |
   "xemu:latest" <- Base Images
 # changelog
 changelogs:
-  - {date: "20.12.25:", desc: "Add libpipewire dep for appimage, head is broken use tag v0.8.133-ls57."}
+  - {date: "20.12.25:", desc: "Add libpipewire dep for appimage, pin to v0.8.133."}
   - {date: "20.12.25:", desc: "Add libusb dep for appimage."}
   - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "07.07.25:", desc: "Install GTK libs for file chooser."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ init_diagram: |
   "xemu:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.12.25:", desc: "Add libpipewire dep for appimage, head is broken use tag v0.8.133-ls57."}
   - {date: "20.12.25:", desc: "Add libusb dep for appimage."}
   - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "07.07.25:", desc: "Install GTK libs for file chooser."}


### PR DESCRIPTION
This is just to get it running, recent changes force xdg-desktop-portal for file opening and pipewire for audio. 

We might need to participate upstream and add a setting for pulseaudio, the deps and runtime for the full desktop portal for a file picker is possible now, but it is messy. 